### PR TITLE
feat: スナップショット自動更新ワークフローを追加

### DIFF
--- a/.github/actions/update-snapshots/action.yml
+++ b/.github/actions/update-snapshots/action.yml
@@ -1,0 +1,66 @@
+name: スナップショット更新
+description: プロジェクトの依存関係をセットアップしてpytestスナップショットを更新する
+
+inputs:
+  commit-message:
+    description: コミットメッセージ
+    required: true
+    default: "test: スナップショット更新"
+
+outputs:
+  has-changes:
+    description: 変更があったかどうか
+    value: ${{ steps.check-changes.outputs.has_changes }}
+
+runs:
+  using: composite
+  steps:
+    - name: <Setup> Python環境セットアップ
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: <Setup> uvのインストール
+      uses: astral-sh/setup-uv@v3
+
+    - name: <Build> 依存関係のインストール
+      run: uv sync --dev
+      shell: bash
+
+    - name: <Build> システム依存関係のインストール
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y festival espeak-ng
+      shell: bash
+
+    - name: <Build> NLTKリソースのダウンロード
+      run: uv run python -c "import nltk; nltk.download('averaged_perceptron_tagger_eng', quiet=True)"
+      shell: bash
+
+    - name: <Deploy> スナップショット更新
+      run: PYTHONPATH=. uv run pytest -sv --snapshot-update
+      shell: bash
+
+    - name: <Deploy> 変更確認
+      id: check-changes
+      run: |
+        if git diff --quiet; then
+          echo "has_changes=false" >> $GITHUB_OUTPUT
+        else
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+
+    - name: <Deploy> 変更をコミット・プッシュ
+      if: steps.check-changes.outputs.has_changes == 'true'
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add .
+        git commit -m "${{ inputs.commit-message }}
+
+        🤖 Generated with GitHub Actions
+
+        Co-Authored-By: GitHub Action <action@github.com>"
+        git push
+      shell: bash

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -1,0 +1,100 @@
+name: スナップショット更新
+
+on:
+  # /update-snapshotsを含むPRコメントでトリガー
+  issue_comment:
+    types: [created]
+
+  # [update.*snapshots]を含むコミットメッセージでトリガー
+  push:
+    branches: ["*"]
+
+jobs:
+  update-snapshots-comment:
+    name: スナップショット更新（PRコメント）
+    runs-on: ubuntu-latest
+    # /update-snapshotsを含むPRコメントでのみ実行
+    if: github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/update-snapshots')
+
+    steps:
+      - name: <Setup> コメントにリアクション追加
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
+
+      - name: <Setup> PRブランチ情報取得
+        id: comment-branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('head_ref', pr.data.head.ref);
+            core.setOutput('head_sha', pr.data.head.sha);
+            return {
+              head_ref: pr.data.head.ref,
+              head_sha: pr.data.head.sha
+            };
+
+      - name: <Setup> PRブランチをチェックアウト
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: <Build/Deploy> スナップショット更新実行
+        id: update-snapshots
+        uses: ./.github/actions/update-snapshots
+        with:
+          commit-message: "test: スナップショット更新"
+
+      - name: <Deploy> 成功リアクション追加
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1'
+            });
+
+      - name: <Deploy> 失敗リアクション追加
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '-1'
+            });
+
+  update-snapshots-commit:
+    name: スナップショット更新（コミットメッセージ）
+    runs-on: ubuntu-latest
+    # [update.*snapshots]パターンにマッチするコミットメッセージのプッシュイベントでのみ実行
+    if: github.event_name == 'push' && contains(github.event.head_commit.message, '[update') && contains(github.event.head_commit.message, 'snapshots]')
+
+    steps:
+      - name: <Setup> 現在のブランチをチェックアウト
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: <Build/Deploy> スナップショット更新実行
+        id: update-snapshots
+        uses: ./.github/actions/update-snapshots
+        with:
+          commit-message: "test: スナップショット更新（自動トリガー）"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,15 @@ PYTHONPATH=. uv run pytest -sv                      # 通常のテスト
 PYTHONPATH=. uv run pytest -sv --snapshot-update    # スナップショットテスト更新
 ```
 
+### CI・自動化
+```bash
+# PRコメントでスナップショット更新（GitHub Actions）
+/update-snapshots
+
+# コミットメッセージでスナップショット更新
+git commit -m "[update snapshots] テスト仕様変更"
+```
+
 ### メインツール実行
 ```bash
 PYTHONPATH=. uv run python tools/process_festival.py "text"     # festival音素解析
@@ -56,10 +65,12 @@ PYTHONPATH=. uv run python tools/extract_feature.py --text_glob "*.txt" --wav_gl
 
 #### 厳格なコーディング規約
 - **コメント禁止**（docstring必須、意図は関数化で明確化）
+  - **例外**: コメントが必要な場合は日本語で記述
 - **型ヒント必須**（引数・返り値すべて）
 - **依存順記述**（依存多→少の順、main関数最上部、private関数最下部）
 - **import順序統一**（最上部配置）
 - **Pathlib強制**（os.path禁止、Path.read_text/read_bytes推奨）
+- **GitHub Actions命名規約**: stepのnameは`<Setup>`, `<Build>`, `<Test>`, `<Deploy>`等のタグ + 日本語説明
 
 #### テスト・CI戦略
 - **pytest.mark.parametrize**による網羅的テストパターン


### PR DESCRIPTION
## Summary
- PRコメント `/update-snapshots` でスナップショット更新機能を追加
- コミットメッセージ `[update.*snapshots]` パターンでの自動更新機能を追加
- 外部依存 `xt0rted/pull-request-comment-branch` を排除し、GitHub API直接呼び出しに変更

## 技術的改善
- 共通処理を composite action に切り出して DRY 原則を適用
- GitHub Actions 命名規約 (`<Setup>`, `<Build>`, `<Deploy>`) を統一
- 日本語コメント規約を CLAUDE.md に明記

## Test plan
- [ ] mainブランチにマージ後、テストPRでスナップショット更新動作を確認
- [ ] PRコメント `/update-snapshots` での動作確認
- [ ] コミットメッセージパターンでの自動トリガー確認

🤖 Generated with [Claude Code](https://claude.ai/code)